### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [14/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-ntp.json
+++ b/chef/data_bags/crowbar/bc-template-ntp.json
@@ -10,6 +10,10 @@
   "deployment": {
     "ntp": {
       "crowbar-revision": 0,
+      "element_states": {
+        "ntp-server": [ "readying", "ready", "applying" ],
+        "ntp-client": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [ "ntp-server", "ntp-client" ]

--- a/chef/data_bags/crowbar/bc-template-ntp.schema
+++ b/chef/data_bags/crowbar/bc-template-ntp.schema
@@ -33,6 +33,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-ntp.json   |    4 ++++
 chef/data_bags/crowbar/bc-template-ntp.schema |   10 ++++++++++
 2 files changed, 14 insertions(+), 0 deletions(-)
