### PR TITLE
Fix the DNS and NTP smoketests to work when the admin node has a public IP address [1/6]

### DIFF
--- a/chef/cookbooks/ntp/recipes/default.rb
+++ b/chef/cookbooks/ntp/recipes/default.rb
@@ -23,7 +23,7 @@ if node["roles"].include?("ntp-client")
     servers = search(:node, "roles:ntp\\-server#{env_filter}")
   end
   ntp_servers = nil
-  ntp_servers = servers.map {|n| Ntp::Evaluator.get_value_by_type(n, :admin_ip_eval) } unless servers.nil?
+  ntp_servers = servers.map {|n| n["fqdn"] } unless servers.nil?
 else
   ntp_servers = node[:ntp][:external_servers]
 end

--- a/smoketest/00-check-ntp.test
+++ b/smoketest/00-check-ntp.test
@@ -22,7 +22,7 @@ ntp_nodes="$(knife_node_find 'roles:ntp-client' FQDN )"
     exit 1
 }
 
-admin_node="$(knife_node_find  "roles:ntp-server" IP )"
+admin_node="$(knife_node_find  "roles:ntp-server" FQDN )"
 
 for node in $ntp_nodes; do
     if run_on "$node" pidof ntpd &>/dev/null; then


### PR DESCRIPTION
The DNS and NTP smoketests were using knife to grab the IP address to
perform sanity tests of the DNS and NTP subsystems.  These tests fail
whenever the admin node has a public IP address, which the current
smoketest framework enables.

The NTP smoketest was fixed by having the NTP recipe set the clients
up to look up the nameserver by FQDN instead of IP.

The DNS smoketest was fixed by removing the part that explicitly 
sanity-tests the resolv.conf -- it will be implicitly tested by the
nslookup commands that happen immediatly afterwards.

Also updated the sledgehammer.ks to not strip out 32 bit packages on
CentOS 6.2 only, and fixed where dev was not checking out the right
branch when doing a build.

 chef/cookbooks/ntp/recipes/default.rb |    2 +-
 smoketest/00-check-ntp.test           |    2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
