### PR TITLE
Move the crowbar.yml layout to v2 [12/27]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Author: RobHirschfeld
-#
 
 barclamp:
   name: ntp
@@ -23,7 +21,7 @@ barclamp:
     - crowbar
 
 crowbar:
-  layout: 1
+  layout: 2
   order: 50
   run_order: 50
   chef_order: 50

--- a/crowbar_framework/doc/default/ntp/barclamp-info.md
+++ b/crowbar_framework/doc/default/ntp/barclamp-info.md
@@ -1,0 +1,5 @@
+### NTP Barclamp
+
+This barclamp sets up the Network Time Protocol (NTP) server and points the nodes to it for time synchronization
+
+

--- a/crowbar_framework/doc/default/ntp/licenses.md
+++ b/crowbar_framework/doc/default/ntp/licenses.md
@@ -1,0 +1,10 @@
+### Deployer Barclamp Licenses
+
+This file contains information (if updated by the barclamp authors!) about the licenses that apply to your installation.
+
+The following dependencies are required:
+
+* ?
+
+
+

--- a/crowbar_framework/doc/ntp.yml
+++ b/crowbar_framework/doc/ntp.yml
@@ -1,0 +1,11 @@
+# theses are the default meta_data values
+license:    Apache 2
+copyright:  2012 by Dell, Inc
+date:       July 25, 2012
+
+crowbar+book-barclamps:
+  ntp+barclamp-info
+    
+crowbar+book-licenses:
+  crowbar+licenses-crowbar-meta:
+    ntp+licenses


### PR DESCRIPTION
Recent changes to add the database required us to update
the layout version.

I also added a doc skeleton while I was touching everything

 crowbar.yml                                        |    4 +---
 crowbar_framework/doc/default/ntp/barclamp-info.md |    5 +++++
 crowbar_framework/doc/default/ntp/licenses.md      |   10 ++++++++++
 crowbar_framework/doc/ntp.yml                      |   11 +++++++++++
 4 files changed, 27 insertions(+), 3 deletions(-)
