### PR TITLE
re-factor out intialize method in controllers [8/22]

### DIFF
--- a/crowbar_framework/app/controllers/ntp_controller.rb
+++ b/crowbar_framework/app/controllers/ntp_controller.rb
@@ -14,8 +14,13 @@
 # 
 
 class NtpController < BarclampController
-  def initialize
+  before_filter :set_service_object
+ 
+  def set_service_object
     @service_object = NtpService.new logger
   end
+
+  private :set_service_object
+
 end
 


### PR DESCRIPTION
Fixed problem with layout rendering due to initialize method not calling super.  Refactored to use before_filter method to load @service_object and deleted initialize method.

 .../app/controllers/ntp_controller.rb              |   47 +++++++++++---------
 1 files changed, 26 insertions(+), 21 deletions(-)
