### PR TITLE
Fixups to add enough default attributes to some roles to test them on an admin node. [3/7]

### DIFF
--- a/bc-template-ntp.json
+++ b/bc-template-ntp.json
@@ -3,8 +3,7 @@
   "description": "Common NTP service for the cluster. An NTP server or servers can be specified and all other nodes will be clients of them.",
   "attributes": {
     "ntp": {
-      "external_servers": [ ],
-      "admin_ip_eval": "node.address.addr"
+      "external_servers": [ ]
     }
   },
   "deployment": {

--- a/bc-template-ntp.schema
+++ b/bc-template-ntp.schema
@@ -16,8 +16,7 @@
               "type": "seq",
               "required": true,
               "sequence": [ { "type": "str" } ]
-            },
-            "admin_ip_eval": { "type": "str", "required": true }
+            }
           }
         }
       }

--- a/chef/roles/ntp-client.rb
+++ b/chef/roles/ntp-client.rb
@@ -4,6 +4,6 @@ description "NTP Client Role - NTP client for the cloud points to Master"
 run_list(
          "recipe[ntp]"
 )
-default_attributes()
+default_attributes "ntp" => { "config" => { "environment" => "ntp-base-config" } }
 override_attributes()
 

--- a/chef/roles/ntp-server.rb
+++ b/chef/roles/ntp-server.rb
@@ -4,6 +4,6 @@ description "NTP Servier Role - NTP master for the cloud"
 run_list(
          "recipe[ntp]"
 )
-default_attributes()
+default_attributes "ntp" => { "external_servers" => [], "config" => { "environment" => "ntp-base-config" } }
 override_attributes()
 


### PR DESCRIPTION
Aside from Chef 11 fixups, the default attributes are inteded to be a
placeholder until the chef jig is working well enough to handle
attribute import and export.

Roles that have been validated so far are:
- deployer-client
- dns-client
- ntp-server
- logging-server

Roles that have been half-validated (recipes run without error, but
functionality is missing:
- bmc-nat-router: Needs the network BC to have injected attributed
  for the networks onto the node.
- dns-server: Ditto

Roles that have nbeen modified, but not tested:
- logging-client:  Cannot test until we have another node, as
  logging-client and logging-server cannot coexist on the same node.
- ipmi-discover and ipmi-configure: Need real hardware to
  meaningfully test these barclamps.
- provisioner-base and provisioner-server:  Need a semi-functional
  DNS server and network BC to make any reasonable progress here.
  
  bc-template-ntp.json     |    3 +--
  bc-template-ntp.schema   |    3 +--
  chef/roles/ntp-client.rb |    2 +-
  chef/roles/ntp-server.rb |    2 +-
  4 files changed, 4 insertions(+), 6 deletions(-)

Crowbar-Pull-ID: c57e28f294ea94c640dee96a8a8c4ce5db59bb8e

Crowbar-Release: development
