### PR TITLE
Add enough default attributes to some roles to test them on an admin server. [3/7]

### DIFF
--- a/bc-template-ntp.json
+++ b/bc-template-ntp.json
@@ -3,8 +3,7 @@
   "description": "Common NTP service for the cluster. An NTP server or servers can be specified and all other nodes will be clients of them.",
   "attributes": {
     "ntp": {
-      "external_servers": [ ],
-      "admin_ip_eval": "node.address.addr"
+      "external_servers": [ ]
     }
   },
   "deployment": {

--- a/bc-template-ntp.schema
+++ b/bc-template-ntp.schema
@@ -16,8 +16,7 @@
               "type": "seq",
               "required": true,
               "sequence": [ { "type": "str" } ]
-            },
-            "admin_ip_eval": { "type": "str", "required": true }
+            }
           }
         }
       }

--- a/chef/roles/ntp-client.rb
+++ b/chef/roles/ntp-client.rb
@@ -4,6 +4,6 @@ description "NTP Client Role - NTP client for the cloud points to Master"
 run_list(
          "recipe[ntp]"
 )
-default_attributes()
+default_attributes "ntp" => { "config" => { "environment" => "ntp-base-config" } }
 override_attributes()
 

--- a/chef/roles/ntp-server.rb
+++ b/chef/roles/ntp-server.rb
@@ -4,6 +4,6 @@ description "NTP Servier Role - NTP master for the cloud"
 run_list(
          "recipe[ntp]"
 )
-default_attributes()
+default_attributes "ntp" => { "external_servers" => [], "config" => { "environment" => "ntp-base-config" } }
 override_attributes()
 


### PR DESCRIPTION
Roles that have been tested:

roles for server:
   deployer-client -- OK
   bmc-nat-router -- OK
   dns-server -- tested, will need network bc.
   dns-client -- OK
   ntp-server -- OK
   logging-server -- OK
   logging-client -- not tested, cannot run with logging-server
   ipmi-discover -- not tested, need real hardware
   ipmi-configure -- not tested, need real hardware
   provisioner-base -- not tested, need working DNS and network.
   provisioner-server -- Not tested, need working DNS and network.

 bc-template-ntp.json     |    3 +--
 bc-template-ntp.schema   |    3 +--
 chef/roles/ntp-client.rb |    2 +-
 chef/roles/ntp-server.rb |    2 +-
 4 files changed, 4 insertions(+), 6 deletions(-)

Crowbar-Pull-ID: b29260d1a62efa73a3928f732a6a1e5316498543

Crowbar-Release: development
