### PR TITLE
Fix ntp smoke test and small git-barclamp deprication [2/2]

### DIFF
--- a/smoketest/00-check-ntp.test
+++ b/smoketest/00-check-ntp.test
@@ -32,7 +32,7 @@ for node in $ntp_nodes; do
         exit 1
     fi
 
-    if run_on "$node"  grep "^server\ $admin_node$" /etc/ntp.conf &>/dev/null; then
+    if run_on "$node"  grep "^server\ $admin_node " /etc/ntp.conf &>/dev/null; then
         echo "$(date '+%F %T %z'): Ntp is pointed to the correct ntp server on node $node."
     else
         echo "$(date '+%F %T %z'): Ntp is NOT pointed to the correct ntp server on node $node."


### PR DESCRIPTION
Fix ntp smoke test pattern match 

Fix small git-barclamp issue that spews deprecation msgs into log.

 smoketest/00-check-ntp.test |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: f93ee6da089135b5255053486ada9c325839b955

Crowbar-Release: pebbles
