### PR TITLE
Add logging and NTP barclamps into the admin node bootstrap. [3/5]

### DIFF
--- a/chef/cookbooks/ntp/recipes/default.rb
+++ b/chef/cookbooks/ntp/recipes/default.rb
@@ -17,15 +17,14 @@ package "ntp" do
     action :install
 end
 
-if node["roles"].include?("ntp-client")
-  unless Chef::Config[:solo]
-    env_filter = " AND environment:#{node[:ntp][:config][:environment]}"
-    servers = search(:node, "roles:ntp\\-server#{env_filter}")
+if node["roles"].include?("ntp-server")
+  ntp_servers = node[:crowbar][:ntp][:external_servers]
+  unless node[:crowbar][:ntp][:servers] &&
+      node[:crowbar][:ntp][:servers].include?(node.address.addr)
+    node.set[:crowbar][:ntp][:servers] = [ node.address.addr ]
   end
-  ntp_servers = nil
-  ntp_servers = servers.map {|n| n["fqdn"] } unless servers.nil?
 else
-  ntp_servers = node[:ntp][:external_servers]
+  ntp_servers = node[:crowbar][:ntp][:servers]
 end
 
 user "ntp"

--- a/chef/cookbooks/ntp/templates/default/ntp.conf.erb
+++ b/chef/cookbooks/ntp/templates/default/ntp.conf.erb
@@ -18,7 +18,7 @@ server 127.127.1.0
 fudge 127.127.1.0 stratum 1
 <% else -%>
 <% @ntp_servers.each do |ntp_server| -%>
-server <%= ntp_server %>
+server <%= ntp_server %> iburst minpoll 4
 <% end -%>
 <% end -%>
 

--- a/chef/roles/ntp-client.rb
+++ b/chef/roles/ntp-client.rb
@@ -4,6 +4,6 @@ description "NTP Client Role - NTP client for the cloud points to Master"
 run_list(
          "recipe[ntp]"
 )
-default_attributes "ntp" => { "config" => { "environment" => "ntp-base-config" } }
+default_attributes()
 override_attributes()
 

--- a/chef/roles/ntp-client/role-template.json
+++ b/chef/roles/ntp-client/role-template.json
@@ -1,35 +1,3 @@
 {
-  "id": "bc-template-ntp",
-  "description": "Common NTP service for the cluster. An NTP server or servers can be specified and all other nodes will be clients of them.",
-  "attributes": {
-    "ntp": {
-      "external_servers": [ ]
-    }
-  },
-  "roles": {
-      "ntp-client": { "implicit": true, "jig": "chef" },
-      "ntp-server": { "admin_implicit": true, "jig": "chef" }
-  },
-  "deployment": {
-    "ntp": {
-      "crowbar-revision": 0,
-      "element_states": {
-        "ntp-server": [ "readying", "ready", "applying" ],
-        "ntp-client": [ "readying", "ready", "applying" ]
-      },
-      "elements": {},
-      "element_order": [
-        [ "ntp-server", "ntp-client" ]
-      ],
-      "config": {
-        "environment": "ntp-base-config",
-        "mode": "full",
-        "transitions": true,
-        "transition_list": [
-          "discovered"
-        ]
-      }
-    }
-  }
 }
 

--- a/chef/roles/ntp-server.rb
+++ b/chef/roles/ntp-server.rb
@@ -4,6 +4,6 @@ description "NTP Servier Role - NTP master for the cloud"
 run_list(
          "recipe[ntp]"
 )
-default_attributes "ntp" => { "external_servers" => [], "config" => { "environment" => "ntp-base-config" } }
+default_attributes()
 override_attributes()
 

--- a/chef/roles/ntp-server/role-template.json
+++ b/chef/roles/ntp-server/role-template.json
@@ -1,35 +1,7 @@
 {
-  "id": "bc-template-ntp",
-  "description": "Common NTP service for the cluster. An NTP server or servers can be specified and all other nodes will be clients of them.",
-  "attributes": {
-    "ntp": {
-      "external_servers": [ ]
+    "crowbar": {
+        "ntp": {
+            "external_servers": [ ]
+        }
     }
-  },
-  "roles": {
-      "ntp-client": { "implicit": true, "jig": "chef" },
-      "ntp-server": { "admin_implicit": true, "jig": "chef" }
-  },
-  "deployment": {
-    "ntp": {
-      "crowbar-revision": 0,
-      "element_states": {
-        "ntp-server": [ "readying", "ready", "applying" ],
-        "ntp-client": [ "readying", "ready", "applying" ]
-      },
-      "elements": {},
-      "element_order": [
-        [ "ntp-server", "ntp-client" ]
-      ],
-      "config": {
-        "environment": "ntp-base-config",
-        "mode": "full",
-        "transitions": true,
-        "transition_list": [
-          "discovered"
-        ]
-      }
-    }
-  }
 }
-

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -32,6 +32,22 @@ crowbar:
   run_order: 50
   chef_order: 50
 
+roles:
+  - name: ntp-server
+    jig: chef
+    requires:
+      - dns-client
+      - network-admin
+    flags:
+      - bootstrap
+  - name: ntp-client
+    jig: chef
+    requires:
+      - ntp-server
+      - network-admin
+    flags:
+      - discovery
+
 debs:
   pkgs:
     - ntp


### PR DESCRIPTION
Fix up the NTP and logging barclamps to allow them to be deployed, and
fix up bugs introduced by the last pull request series.

 chef/cookbooks/ntp/recipes/default.rb             |   13 ++++----
 chef/cookbooks/ntp/templates/default/ntp.conf.erb |    2 +-
 chef/roles/ntp-client.rb                          |    2 +-
 chef/roles/ntp-client/role-template.json          |   32 ------------------
 chef/roles/ntp-server.rb                          |    2 +-
 chef/roles/ntp-server/role-template.json          |   36 +++------------------
 crowbar.yml                                       |   16 +++++++++
 7 files changed, 29 insertions(+), 74 deletions(-)

Crowbar-Pull-ID: 3ad87c72b743e6a5474ec33caf2b57249b136059

Crowbar-Release: development
