### PR TITLE
IPV6, node availability, sledgehammer bootstrapping, delayed_jobs, oh my! [4/9]

### DIFF
--- a/chef/cookbooks/ntp/recipes/default.rb
+++ b/chef/cookbooks/ntp/recipes/default.rb
@@ -21,7 +21,7 @@ if node["roles"].include?("ntp-server")
   ntp_servers = node[:crowbar][:ntp][:external_servers]
   unless node[:crowbar][:ntp][:servers] &&
       node[:crowbar][:ntp][:servers].include?(node.address.addr)
-    node.set[:crowbar][:ntp][:servers] = [ node.address.addr ]
+    node.set[:crowbar][:ntp][:servers] = node.addresses("admin").map{|a|a.addr}
   end
 else
   ntp_servers = node[:crowbar][:ntp][:servers]


### PR DESCRIPTION
Lots of changes in this pull request series:
- IPv6.  All nodes on the admin network get a free shiny IPv6 address,
  and the core services have been modified to work equally well over
  IPv6 and IPv4 to the extent testable so far.  By default, we create
  an RFC4193 address range for the network, and synthesize the host
  part of the address based on the node name.
- Delayed_jobs.  Each individual jig run for a node role happens has a
  delayed job.  The annealer has been modified to ensure that we only
  ever run 1 job per node at a time to ensure that we do not violate
  ordering constraints, and we will run up to 10 jobs in parallel.
  The converge API is gone -- the crowbar_converge command
  demonstrates how to use anneal to drive a cluster towards a
  converged state.
- Node aliveness and availability.  Nodes have seperate notions of
  aliveness (the node is reachable and is capable of running things)
  and availability (the node is being managed by Crowbar.)  Nodes must
  be alive and available for the annealer to do anything with them.
- Sledgehammer bootstrapping.  The annealer will attempt to run jobs
  against nodes operating in Sledgehammer.
  
  chef/cookbooks/ntp/recipes/default.rb |    2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: fda77fb192c9c1d39e5891586544cf031c6d65bf

Crowbar-Release: development
