### PR TITLE
Update role binding logic to facilitate running a real workload on Crowbar 2.0 [4/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -39,7 +39,6 @@ roles:
       - dns-client
       - network-admin
     flags:
-      - bootstrap
       - server
   - name: ntp-client
     jig: chef
@@ -48,8 +47,7 @@ roles:
       - ntp-server
       - network-admin
     flags:
-      - discovery
-
+      - implicit
 debs:
   pkgs:
     - ntp


### PR DESCRIPTION
 Fix up role logic to help support Ceph
- Add utility roles that other roles can easily depend on to tell when a
  node is in certian states.  Currently, these are:
  - crowbar-managed-node, which indicates that a node has completed the
    initial discovery process,
  - crowbar-admin-node, which indicates that the admin node is alive and
    ready to manage other nodes, and
  - crowbar-installed-node, which indicates that the node has an
    operating system installed and is ready to have a workload deployed on
    it.
- Add on_deployemnt_create and on_deployment_delete hooks to the role
  model.  These are called whenever a deployment role is created or
  destroyed to allow roles to preseed deployment-specific values.  They
  are currently used by the Ceph barclamp to randomly generate unique
  fsid and monitor secrets..
- Add a cluster flag and accompaining logic to roles.  When a role has
  the cluster flag set, add_to_node_in_snapshot will ensure that all of
  the noderoles created as children of any noderoles created for
  noderoles with the cluster flag are fully connected -- all the
  children will depend on all the parents.  This is used to ensure that
  no child noderole will start deploying until all of its parents have
  completed their deploys.
- Modified add_to_node_in_snapshot to recursively create all parent
  noderoles, instead of only doing so with implicit noderoles.
- Modify how we queue roles up for delayed_jobs to be a little more
  stable.
  
  crowbar.yml | 4 +---
  1 file changed, 1 insertion(+), 3 deletions(-)

Crowbar-Pull-ID: f28b0c0c0dce9879a7994eaa07e17b3068198e63

Crowbar-Release: development
