### PR TITLE
Make role attributes work, and add some to play around with in CB 2.0 [4/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -40,6 +40,10 @@ roles:
       - network-admin
     flags:
       - server
+    attribs:
+      - name: ntp_servers
+        description: "Addresses of the NTP servers to use for cluster-wide time synchronization"
+        map: 'crowbar/ntp/servers'
   - name: ntp-client
     jig: chef-solo
     requires:
@@ -48,6 +52,8 @@ roles:
       - network-admin
     flags:
       - implicit
+    wants-attribs:
+      - ntp_servers
 debs:
   pkgs:
     - ntp


### PR DESCRIPTION
- Make Attrib.get smart. Instead of passing a blob of JSON, it now
  accepts the object it should try to work with. This centralizes the
  logic around what fields in an object are valid places to get
  attributes from, and will fail hard if you pass it something that
  should not work with the attribute system.
- Add matching Attrib.set methods. This provides an abstract interface
  for setting attributes on objects that matches the use of
  Attrib.get.
- Add some attributes to various nodes to lay the groundwork for
  adding logic to the annealer to make it consiter attribute visibility.
- Numerous trivial cleanups to make things work with the above changes.
  
  crowbar.yml | 6 ++++++
  1 file changed, 6 insertions(+)

Crowbar-Pull-ID: cd953079fcc42015c6552d4b6d190cc54e898308

Crowbar-Release: development
