### PR TITLE
Flesh out wanted_attrs handling, and add some infrastructure for using it. [3/6]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -53,7 +53,8 @@ roles:
     flags:
       - implicit
     wants-attribs:
-      - ntp_servers
+      - name: ntp_servers
+        at: 'crowbar/ntp/servers'
 debs:
   pkgs:
     - ntp


### PR DESCRIPTION
This pull request series lays more groundwork for making how we handle
making sure that jig runs get just the attributes they need, instead
of a bunch of excess ones that they probably shold not have access to
anyways.
- Allow wanted_attrs to declare where they want the attribute data at
  when the jig infrastructire builds its JSON blob to hand off to the
  jig.  This will allow for a modicum of location independence between
  how roles export their attributes vs. how they import them.
- Optimize how we get all the ancestors and descendants of a given
  noderole to kill some excess ournd trips to the SQL server by moving
  the query recursion from Rails into postgresql.
  
  crowbar.yml | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 435923b0a0746ceaecb6283577ca9f9f79e1be4a

Crowbar-Release: development
