### PR TITLE
Improvement for high availability

### DIFF
--- a/chef/cookbooks/ntp/templates/default/ntp.conf.erb
+++ b/chef/cookbooks/ntp/templates/default/ntp.conf.erb
@@ -14,12 +14,14 @@ filegen clockstats file clockstats type day enable
 
 # You do need to talk to an NTP server or two (or three).
 <% if @ntp_servers.nil? or @ntp_servers.empty? -%>
-server 127.127.1.0 minpoll 3 burst
+server 127.127.1.0 minpoll 4 burst iburst
 fudge 127.127.1.0 stratum 1
 <% else -%>
 <% @ntp_servers.each do |ntp_server| -%>
-server <%= ntp_server %> iburst minpoll 4
+server <%= ntp_server %> minpoll 4 burst iburst
 <% end -%>
+server 127.127.1.0 minpoll 8 burst
+fudge 127.127.1.0 stratum 16
 <% end -%>
 
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for


### PR DESCRIPTION
I would like to propose following solution which resolve problem with crashes of `ntp-server` or defined by user `external-ntp-servers`. 

This fix lets to `ntp-server` crash or network problems without affecting clock stability in the system. Because internal clock is fudged to have stratum 16, which is really low, it  has always the lowest priority. If `ntp-server` will be available clock will synchronized with them.

I've tested many different expanded configurations, but this patch seems to be the most reasonable solutions. 
