### PR TITLE
Allow SLE12 nodes for ntp-server

### DIFF
--- a/crowbar_framework/app/models/ntp_service.rb
+++ b/crowbar_framework/app/models/ntp_service.rb
@@ -29,7 +29,6 @@ class NtpService < ServiceObject
           "count" => -1,
           "admin" => true,
           "exclude_platform" => {
-            "suse" => "12.0",
             "windows" => "/.*/"
           }
         },


### PR DESCRIPTION
There's no need to change anything in the cookbook, it just works.